### PR TITLE
Integrate with huggingface

### DIFF
--- a/michelangelo/models/asl_diffusion/clip_asl_diffuser_pl_module.py
+++ b/michelangelo/models/asl_diffusion/clip_asl_diffuser_pl_module.py
@@ -10,6 +10,7 @@ from torch.optim import lr_scheduler
 import pytorch_lightning as pl
 from pytorch_lightning.utilities import rank_zero_only
 from huggingface_hub import PyTorchModelHubMixin
+from omegaconf import OmegaConf
 
 from diffusers.schedulers import (
     DDPMScheduler,
@@ -52,6 +53,12 @@ class ClipASLDiffuser(pl.LightningModule,
                  ignore_keys: Union[Tuple[str], List[str]] = ()):
 
         super().__init__()
+        first_stage_config = OmegaConf.create(first_stage_config)
+        cond_stage_config = OmegaConf.create(cond_stage_config)
+        denoiser_cfg = OmegaConf.create(denoiser_cfg)
+        scheduler_cfg = OmegaConf.create(scheduler_cfg)
+        optimizer_cfg = OmegaConf.create(optimizer_cfg)
+        loss_cfg = OmegaConf.create(loss_cfg)
 
         self.first_stage_key = first_stage_key
         self.cond_stage_key = cond_stage_key

--- a/michelangelo/models/asl_diffusion/clip_asl_diffuser_pl_module.py
+++ b/michelangelo/models/asl_diffusion/clip_asl_diffuser_pl_module.py
@@ -33,7 +33,11 @@ def disabled_train(self, mode=True):
 
 
 class ClipASLDiffuser(pl.LightningModule,
-                      PyTorchModelHubMixin):
+                      PyTorchModelHubMixin,
+                      library_name="michelangelo",
+                      repo_url="https://github.com/NeuralCarver/Michelangelo",
+                      tags=["image-to-3d"]
+                      ):
     first_stage_model: Optional[AlignedShapeAsLatentPLModule]
     cond_stage_model: Optional[Union[nn.Module, pl.LightningModule]]
     model: nn.Module


### PR DESCRIPTION
## this pr will mainly add 3 methods to michelangelo

* `save_pretrained`
* `push_to_hub`
* `from_pretrained`: initialize and load the model weights

allowing your models to be easily integrated with huggingface using the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class, I made this notebook https://colab.research.google.com/drive/1rStTsfAqoT7wXijt4a2wPbd6ZUYG3jTc?usp=sharing  explaining how to migrate your weights
by the end of the notebook, all users can load your model simply by 
```python
!!pip install -qU git+https://github.com/not-lain/Michelangelo.git@integrate-with-huggingface # or your main branch when this is merged
# no more renitializing the model and manually downloading the weights

from michelangelo.models.asl_diffusion.clip_asl_diffuser_pl_module import ClipASLDiffuser
# will instantiate the model and load the weights automatically
new_model = ClipASLDiffuser.from_pretrained("not-lain/Michelangelo")
```

## Why you should integrate your model with huggingface ?

* easily save, load and push your model
* Keep track on how many times your model has been downloaded by the community (download metrics will be enabled again)
* Automatic model card generation: the metadata in the card allows you to filter your [searches](https://huggingface.co/models?other=michelangelo) easily to check how many michelangelo models exist on the Hub.
* Recommended: after this pr is merged we can open a pull request [on this file](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) to make the "michelangelo" library official on the Hub meaning better discoverability + possibility to add code snippets.

do not hesitate if you have any reviews on the pr or any questions.
 
Kind regards, 
Hafedh Hichri
